### PR TITLE
Copyable Label and Fix Transaction Awaiting state overlapping views

### DIFF
--- a/breadwallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/breadwallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/atmcoin/cash-ui-ios.git",
         "state": {
           "branch": null,
-          "revision": "6d3fe1afb23365b386c8a412db4fca6adc57908a",
-          "version": "4.0.0"
+          "revision": "aaf721c5e48f363b6766f8a31bdf33bfc74bb0a1",
+          "version": "4.1.0"
         }
       },
       {

--- a/breadwallet/JustCash/Resources/XIB/WithdrawalStatusView.xib
+++ b/breadwallet/JustCash/Resources/XIB/WithdrawalStatusView.xib
@@ -168,7 +168,7 @@
                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="xWV-4X-Fts" userLabel="Address Label">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="xWV-4X-Fts" userLabel="Address Label" customClass="CopyableLabel" customModule="CashUI">
                     <rect key="frame" x="131" y="528.5" width="58.5" height="29"/>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
                     <nil key="textColor"/>


### PR DESCRIPTION
Upgrade to a new version of CashUI. Copyable Label and fix to the Awaiting state that was showing overlapping views on transaction details page