### PR TITLE
Tab Bar Buttons Fix

### DIFF
--- a/breadwallet/src/Extensions/UIButton+BRWAdditions.swift
+++ b/breadwallet/src/Extensions/UIButton+BRWAdditions.swift
@@ -11,23 +11,25 @@ import CashUI
 
 extension UIButton {
     static func vertical(title: String, image: UIImage, size: CGSize) -> UIButton {
+        // Avoid bar button text to grow with the accessibility text size
+        let font = UIFont.systemFont(ofSize: 12)
+        
         let button = UIButton(type: .system)
         button.setTitle(title, for: .normal)
         button.setImage(image, for: .normal)
-        button.titleLabel?.font = Theme.caption
+        button.titleLabel?.font = font // Theme.caption
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .center
         button.contentMode = .center
         button.imageView?.contentMode = .center
-        if let imageSize = button.imageView?.image?.size,
-            let font = button.titleLabel?.font {
+        button.accessibilityLabel = title
+        if let imageSize = button.imageView?.image?.size {
             let spacing: CGFloat = C.padding[1]/2.0
             let oneLineHeight = NSString(string: "one line").size(withAttributes: [NSAttributedString.Key.font: font]).height
             let titleSize = NSString(string: title).boundingRect(with: CGSize(width: size.width, height: size.height), options: [.usesLineFragmentOrigin], attributes: [NSAttributedString.Key.font: font], context: nil).size
 
             // These edge insets place the image vertically above the title label
             button.titleEdgeInsets = UIEdgeInsets(top: 0.0, left: -imageSize.width, bottom: -(26.0 + spacing + (titleSize.height - oneLineHeight)), right: 0.0)
-            // -(titleSize.height + spacing)
             button.imageEdgeInsets = UIEdgeInsets(top: -C.padding[2], left: 0.0, bottom: 0.0, right: -titleSize.width)
         }
         return button

--- a/breadwallet/src/Extensions/UIButton+BRWAdditions.swift
+++ b/breadwallet/src/Extensions/UIButton+BRWAdditions.swift
@@ -10,21 +10,25 @@ import UIKit
 import CashUI
 
 extension UIButton {
-    static func vertical(title: String, image: UIImage) -> UIButton {
+    static func vertical(title: String, image: UIImage, size: CGSize) -> UIButton {
         let button = UIButton(type: .system)
         button.setTitle(title, for: .normal)
         button.setImage(image, for: .normal)
         button.titleLabel?.font = Theme.caption
+        button.titleLabel?.numberOfLines = 0
+        button.titleLabel?.textAlignment = .center
         button.contentMode = .center
         button.imageView?.contentMode = .center
         if let imageSize = button.imageView?.image?.size,
             let font = button.titleLabel?.font {
             let spacing: CGFloat = C.padding[1]/2.0
-            let titleSize = NSString(string: title).size(withAttributes: [NSAttributedString.Key.font: font])
+            let oneLineHeight = NSString(string: "one line").size(withAttributes: [NSAttributedString.Key.font: font]).height
+            let titleSize = NSString(string: title).boundingRect(with: CGSize(width: size.width, height: size.height), options: [.usesLineFragmentOrigin], attributes: [NSAttributedString.Key.font: font], context: nil).size
 
             // These edge insets place the image vertically above the title label
-            button.titleEdgeInsets = UIEdgeInsets(top: 0.0, left: -imageSize.width, bottom: -(26.0 + spacing), right: 0.0)
-            button.imageEdgeInsets = UIEdgeInsets(top: -(titleSize.height + spacing), left: 0.0, bottom: 0.0, right: -titleSize.width)
+            button.titleEdgeInsets = UIEdgeInsets(top: 0.0, left: -imageSize.width, bottom: -(26.0 + spacing + (titleSize.height - oneLineHeight)), right: 0.0)
+            // -(titleSize.height + spacing)
+            button.imageEdgeInsets = UIEdgeInsets(top: -C.padding[2], left: 0.0, bottom: 0.0, right: -titleSize.width)
         }
         return button
     }

--- a/breadwallet/src/ViewControllers/HomeScreenViewController.swift
+++ b/breadwallet/src/ViewControllers/HomeScreenViewController.swift
@@ -231,17 +231,22 @@ class HomeScreenViewController: UIViewController, Subscriber, Trackable {
     }
     
     private func setupToolbar() {
-        let buttons = [("ATM Cash Redeem", #imageLiteral(resourceName: "cashout"), #selector(redeem)),
-                       ("Scan QR Code", #imageLiteral(resourceName: "qrcode"), #selector(scanQR)),
-                       ("Activity", #imageLiteral(resourceName: "activity"), #selector(activity)),
-                       (S.HomeScreen.menu, #imageLiteral(resourceName: "menu"), #selector(menu))].map { (title, image, selector) -> UIBarButtonItem in
-                        let button = UIButton.vertical(title: title, image: image)
-                        button.tintColor = .navigationTint
-                        button.addTarget(self, action: selector, for: .touchUpInside)
-                        return UIBarButtonItem(customView: button)
+        let items = [("Scan QR Code", #imageLiteral(resourceName: "qrcode"), #selector(scanQR)),
+                     ("ATM Cash Redeem", #imageLiteral(resourceName: "cashout"), #selector(redeem)),
+                     ("Activity", #imageLiteral(resourceName: "activity"), #selector(activity)),
+                     (S.HomeScreen.menu, #imageLiteral(resourceName: "menu"), #selector(menu))]
+        
+        let paddingWidth = C.padding[2]
+        let buttonWidth = (view.bounds.width - (paddingWidth * CGFloat(items.count+1))) / CGFloat(items.count)
+        let buttonHeight = CGFloat(44.0)
+        
+        let buttons = items.map { (title, image, selector) -> UIBarButtonItem in
+            let button = UIButton.vertical(title: title, image: image, size: CGSize(width: buttonWidth, height: buttonHeight))
+            button.tintColor = .navigationTint
+            button.addTarget(self, action: selector, for: .touchUpInside)
+            return UIBarButtonItem(customView: button)
         }
                 
-        let paddingWidth = C.padding[2]
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         
         toolbar.items = [
@@ -256,10 +261,12 @@ class HomeScreenViewController: UIViewController, Subscriber, Trackable {
             flexibleSpace
         ]
         
-        let buttonWidth = (view.bounds.width - (paddingWidth * CGFloat(buttons.count+1))) / CGFloat(buttons.count)
-        let buttonHeight = CGFloat(44.0)
         buttons.forEach {
             $0.customView?.frame = CGRect(x: 0, y: 0, width: buttonWidth, height: buttonHeight)
+            let currWidth = $0.customView?.widthAnchor.constraint(equalToConstant: buttonWidth)
+            currWidth?.isActive = true
+            let currHeight = $0.customView?.heightAnchor.constraint(equalToConstant: buttonHeight)
+            currHeight?.isActive = true
         }
         
         // Stash the UIButton's wrapped by the toolbar items in case we need add a badge later.


### PR DESCRIPTION
This is my idea of how buttons should look on the tab bar regardless of how many we have (examples provided for 3 or 4 buttons)

* Bottom Bar buttons have the same size regardless of the text contained. Longer texts will wrap to the next line when width of the button is too small to fit it. Currently, the button width depends on the text size (weird looking UI)
NOTE: It does not matter if the user changes the text size on the phone's settings accessibility, the buttons on the bottom bar are not affected - other text might.


![Simulator Screen Shot - iPhone 8 - 2020-11-05 at 09 37 10](https://user-images.githubusercontent.com/602297/98254788-b5055a80-1f4a-11eb-82a3-2e8fadba0282.png)
![Simulator Screen Shot - iPhone 8 - 2020-11-05 at 09 38 30](https://user-images.githubusercontent.com/602297/98254803-b9317800-1f4a-11eb-8d85-ca8d8a5bfd27.png)
