### PR TITLE
Fixes Zero Balances

### DIFF
--- a/breadwallet/KeyStore/KeyStoreUtils.swift
+++ b/breadwallet/KeyStore/KeyStoreUtils.swift
@@ -11,13 +11,13 @@
 import Foundation
 
 var WalletSecAttrService: String {
-    if E.isRunningTests { return "com.brd.testnetQA.tests" }
+    if E.isRunningTests { return "cash.just.testnetQA.tests" }
     #if TESTNET
-    return "com.brd.testnetQA"
+    return "cash.just.testnetQA"
     #elseif INTERNAL
-    return "com.brd.internalQA"
+    return "cash.just.internalQA"
     #else
-    return "org.voisine.breadwallet"
+    return "cash.just.breadwallet"
     #endif
 }
 

--- a/breadwallet/breadwallet.entitlements
+++ b/breadwallet/breadwallet.entitlements
@@ -25,9 +25,5 @@
 	<array>
 		<string>group.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	</array>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)org.voisine.breadwallet</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Fixing keychain attribute service that may have caused customers to get zero balances as it was accessing the wrong keychain item. Upgrading to this new version should recover the item, hence the balances for the user as the keychain does not get removed easily.